### PR TITLE
remove unnecessary import and `const` declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = {
   layouts: {
     all: require('./layouts/all.json')


### PR DESCRIPTION
In order to make sure this library is compatible with IE and doesn't do more than necessary, remove unused require statement.